### PR TITLE
fix: proper oc tar extraction

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -28,7 +28,7 @@ install_executable() {
   wget "$download_url" -O "${path}/${binary}"
   case "$(uname -s)" in
       Darwin|Linux)
-        cd ${path} && tar xzfv ${path}/${binary} oc && cd -
+        cd ${path} && tar xzfv ${path}/${binary} --wildcards --no-anchored '**/oc' --strip 1 && cd -
         ;;
 
       CYGWIN*|MINGW32*|MSYS*)

--- a/bin/install
+++ b/bin/install
@@ -18,17 +18,24 @@ install() {
   local binary="oc-$(get_arch ${version})"
 
   echo "Downloading OpenShift Client ${version} from ${download_url} to ${bin_install_path}"
-  install_executable "${download_url}" "${bin_install_path}" "${binary}"
+  install_executable "${download_url}" "${bin_install_path}" "${binary}" "${version}"
 }
 
 install_executable() {
   local download_url=$1
   local path=$2
   local binary=$3
+  local version=$4
   wget "$download_url" -O "${path}/${binary}"
   case "$(uname -s)" in
       Darwin|Linux)
-        cd ${path} && tar xzfv ${path}/${binary} oc && cd -
+        if [[ $version == v4* ]]; then
+          cd ${path} && tar xzfv ${path}/${binary} oc && cd -
+  	elif [[ $version == v3* ]]; then
+	  cd ${path} && tar xzfv ${path}/${binary} --wildcards --no-anchored '**/oc' --strip 1 && cd -
+	else
+	  echo "Unknown OC major version"
+	fi
         ;;
 
       CYGWIN*|MINGW32*|MSYS*)


### PR DESCRIPTION
Tar extraction is broken:
```bash
$ asdf install oc v3.11.0
Downloading OpenShift Client v3.11.0 from https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz to /home/user/.asdf/installs/oc/v3.11.0/bin
--2020-09-03 16:59:07--  https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://github-production-release-asset-2e65be.s3.amazonaws.com/22442668/bc49e200-cd4b-11e8-867b-80841e1e238f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200903T145907Z&X-Amz-Expires=300&X-Amz-Signature=89d144587c5a9cab9d3337be97566239058a64492279040b9917f621f5bc1664&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=22442668&response-content-disposition=attachment%3B%20filename%3Dopenshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz&response-content-type=application%2Foctet-stream [following]
--2020-09-03 16:59:07--  https://github-production-release-asset-2e65be.s3.amazonaws.com/22442668/bc49e200-cd4b-11e8-867b-80841e1e238f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200903T145907Z&X-Amz-Expires=300&X-Amz-Signature=89d144587c5a9cab9d3337be97566239058a64492279040b9917f621f5bc1664&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=22442668&response-content-disposition=attachment%3B%20filename%3Dopenshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz&response-content-type=application%2Foctet-stream
Resolving github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)... 52.216.132.123
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)|52.216.132.123|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 56507103 (54M) [application/octet-stream]
Saving to: ‘/home/user/.asdf/installs/oc/v3.11.0/bin/oc-linux-64bit.tar.gz’

/home/user/.asdf/installs/oc/v3.11.0/ 100%[=====================================================================================>]  53.89M  6.45MB/s    in 8.6s    

2020-09-03 16:59:16 (6.29 MB/s) - ‘/home/user/.asdf/installs/oc/v3.11.0/bin/oc-linux-64bit.tar.gz’ saved [56507103/56507103]

tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
tar: oc: Not found in archive
tar: Exiting with failure status due to previous errors
```

Fortunately @orphaner already fixed this issue in his fork: https://github.com/orphaner/asdf-oc/commit/70c890473b344b1d9105fe9698db5f8b77d19ef4

Now it works:
```bash
$ asdf install oc v3.11.0
Downloading OpenShift Client v3.11.0 from https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz to /home/user/.asdf/installs/oc/v3.11.0/bin
--2020-09-03 17:07:53--  https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://github-production-release-asset-2e65be.s3.amazonaws.com/22442668/bc49e200-cd4b-11e8-867b-80841e1e238f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200903T150754Z&X-Amz-Expires=300&X-Amz-Signature=faad424da9247d03412343218ba4802fda11340d1a3686431a972516dcf820d9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=22442668&response-content-disposition=attachment%3B%20filename%3Dopenshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz&response-content-type=application%2Foctet-stream [following]
--2020-09-03 17:07:54--  https://github-production-release-asset-2e65be.s3.amazonaws.com/22442668/bc49e200-cd4b-11e8-867b-80841e1e238f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200903T150754Z&X-Amz-Expires=300&X-Amz-Signature=faad424da9247d03412343218ba4802fda11340d1a3686431a972516dcf820d9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=22442668&response-content-disposition=attachment%3B%20filename%3Dopenshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz&response-content-type=application%2Foctet-stream
Resolving github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)... 52.216.227.72
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)|52.216.227.72|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 56507103 (54M) [application/octet-stream]
Saving to: ‘/home/user/.asdf/installs/oc/v3.11.0/bin/oc-linux-64bit.tar.gz’

/home/user/.asdf/installs/oc/v3.11.0/ 100%[=====================================================================================>]  53.89M  11.9MB/s    in 5.5s    

2020-09-03 17:08:00 (9.72 MB/s) - ‘/home/user/.asdf/installs/oc/v3.11.0/bin/oc-linux-64bit.tar.gz’ saved [56507103/56507103]

tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.selinux'
```

Now it would be nice to see this fix merged into this repository.

Thanks and regards,
Philip